### PR TITLE
Re-implemented authentication and registration via OOP concept, following the "tell, don't ask" approach

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Authentication\\": "src/Authentication"
+            "Authentication\\": "src/Authentication",
+            "Infrastructure\\": "src/Infrastructure"
         }
     },
     "require-dev": {

--- a/public/login.php
+++ b/public/login.php
@@ -1,20 +1,25 @@
 <?php
 
-$user = $_POST['emailAddress'];
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$email = $_POST['emailAddress'];
 $password = $_POST['password'];
 
-$existingUsers = json_decode(file_get_contents(__DIR__ . '/../data/users.json'), true);
+$users = new \Infrastructure\Authentication\Repository\FilesystemUsers(__DIR__ . '/../data/users.json');
 
-if (!isset($existingUsers[$user])) {
+if (! $users->exists($email)) {
     echo 'Nope';
 
     return;
 }
 
-if (! password_verify($password, $existingUsers[$user])) {
+$user = $users->get($email);
+
+if (! $user->authenticate($password)) {
     echo 'Nope';
 
     return;
 }
 
-echo 'Ok';
+echo 'OK';
+

--- a/public/register.php
+++ b/public/register.php
@@ -1,25 +1,28 @@
 <?php
 
-// registering a new user:
+require_once __DIR__ . '/../vendor/autoload.php';
 
 $email = $_POST['emailAddress'];
 $password = $_POST['password'];
 
-$existingUsers = json_decode(file_get_contents(__DIR__ . '/../data/users.json'), true);
+$users = new \Infrastructure\Authentication\Repository\FilesystemUsers(__DIR__ . '/../data/users.json');
 
-if (isset($existingUsers[$email])) {
+if ($users->exists($email)) {
     echo 'Already registered';
 
     return;
 }
 
-$hash = password_hash($password, \PASSWORD_DEFAULT);
+$user = new \Authentication\Entity\User(
+    $email,
+    $password
+);
 
-$existingUsers[$email] = $hash;
+$users->store($user);
 
-error_log('Registration mail sent here');
-
-file_put_contents(__DIR__ . '/../data/users.json', json_encode($existingUsers));
+/** @var Notifier $notify */
+// send email abstraction?
+//error_log('Registration mail sent here');
 
 echo 'OK';
 

--- a/src/Authentication/Entity/User.php
+++ b/src/Authentication/Entity/User.php
@@ -4,5 +4,20 @@ namespace Authentication\Entity;
 
 class User
 {
-    
+    /** @var string */
+    public $email;
+
+    /** @var string */
+    public $passwordHash;
+
+    public function __construct(string $email, string $password)
+    {
+        $this->email = $email;
+        $this->passwordHash = password_hash($password, \PASSWORD_DEFAULT);
+    }
+
+    public function authenticate(string $password) : bool
+    {
+        return password_verify($password, $this->passwordHash);
+    }
 }

--- a/src/Authentication/Repository/Users.php
+++ b/src/Authentication/Repository/Users.php
@@ -6,6 +6,7 @@ use Authentication\Entity\User;
 
 interface Users
 {
+    public function exists(string $emailAddress) : bool;
     public function get(string $emailAddress) : User;
     public function store(User $user) : void;
 }

--- a/src/Infrastructure/Authentication/Repository/FilesystemUsers.php
+++ b/src/Infrastructure/Authentication/Repository/FilesystemUsers.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infrastructure\Authentication\Repository;
+
+use Authentication\Entity\User;
+use Authentication\Repository\Users;
+
+final class FilesystemUsers implements Users
+{
+    /** @var string */
+    private $usersPath;
+
+    public function __construct(string $usersPath)
+    {
+        $this->usersPath = $usersPath;
+    }
+
+    public function exists(string $emailAddress) : bool
+    {
+        return isset($this->existingUsers()[$emailAddress]);
+    }
+
+    public function get(string $emailAddress) : User
+    {
+        $existingUsers = $this->existingUsers();
+
+        if (! isset($existingUsers[$emailAddress])) {
+            throw new \UnexpectedValueException(sprintf('User %s does not exist', $emailAddress));
+        }
+
+        $user = (new \ReflectionClass(User::class))->newInstanceWithoutConstructor();
+
+        $user->email = $emailAddress;
+        $user->passwordHash = $existingUsers[$emailAddress];
+
+        return $user;
+    }
+
+    public function store(User $user) : void
+    {
+        $existingUsers = $this->existingUsers();
+
+        $existingUsers[$user->email] = $user->passwordHash;
+
+        file_put_contents($this->usersPath, json_encode($existingUsers));
+    }
+
+    /** @return array<string, string> */
+    private function existingUsers() : array
+    {
+        return json_decode(file_get_contents($this->usersPath), true);
+    }
+}


### PR DESCRIPTION
Refactored #1 into:

 * an `Entity\User` that is abstracting the `authenticate` interaction
 * a repository that implements storage of `User` instances into a simplified JSON storages, and populates `User` state via public property access

This approach starts giving names, labels and clear identities to the various bits of code being involved.